### PR TITLE
Improve grandparent calculation

### DIFF
--- a/source/Projectile.cpp
+++ b/source/Projectile.cpp
@@ -52,8 +52,8 @@ Projectile::Projectile(const Ship &parent, Point position, Angle angle, const We
 	if(inaccuracy)
 		this->angle += Angle::Random(inaccuracy) - Angle::Random(inaccuracy);
 
-	marginalVelocity = weapon->Velocity() + Random::Real() * weapon->RandomVelocity();
-	velocity += this->angle.Unit() * marginalVelocity;
+	speed = weapon->Velocity() + Random::Real() * weapon->RandomVelocity();
+	velocity += this->angle.Unit() * speed;
 
 	// If a random lifetime is specified, add a random amount up to that amount.
 	if(weapon->RandomLifetime())
@@ -79,12 +79,13 @@ Projectile::Projectile(const Projectile &parent, const Point &offset, const Angl
 	// But we still want inaccuracy to have an effect on submunitions. Because of
 	// this, we tilt the velocity of submunitions in the direction of the inaccuracy.
 
-	// Find out how much speed the submunition is adding to itself.
-	marginalVelocity = weapon->Velocity() + Random::Real() * weapon->RandomVelocity();
-	// Get the velocity of the grandparent.
-	velocity -= parent.angle.Unit() * parent.marginalVelocity;
-	// Apply the inaccuracy to the parent's velocity as well as the submunition's velocity.
-	velocity += this->angle.Unit() * (parent.marginalVelocity + marginalVelocity);
+	// Calculate the speed of this projectile, which is the speed of the parent
+	// plus whatever speed the submunition adds.
+	speed = parent.speed + weapon->Velocity() + Random::Real() * weapon->RandomVelocity();
+	// Unwind the inaccuracy of the parent.
+	velocity -= parent.angle.Unit() * parent.speed;
+	// Apply the inaccuracy of the submunition.
+	velocity += this->angle.Unit() * speed;
 
 	// If a random lifetime is specified, add a random amount up to that amount.
 	if(weapon->RandomLifetime())

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -105,9 +105,9 @@ private:
 	const Ship *cachedTarget = nullptr;
 	const Government *targetGovernment = nullptr;
 
-	// How much velocity this projectile added to itself on top of the
-	// velocity of its parent.
-	double marginalVelocity = 0.;
+	// How much speed this has been added by all stages
+	// of this projectile.
+	double speed = 0.;
 	double clip = 1.;
 	int lifetime = 0;
 	double distanceTraveled = 0;

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -105,6 +105,9 @@ private:
 	const Ship *cachedTarget = nullptr;
 	const Government *targetGovernment = nullptr;
 
+	// How much velocity this projectile added to itself on top of the
+	// velocity of its parent.
+	double marginalVelocity = 0.;
 	double clip = 1.;
 	int lifetime = 0;
 	double distanceTraveled = 0;

--- a/source/Projectile.h
+++ b/source/Projectile.h
@@ -105,8 +105,7 @@ private:
 	const Ship *cachedTarget = nullptr;
 	const Government *targetGovernment = nullptr;
 
-	// How much speed this has been added by all stages
-	// of this projectile.
+	// How much speed has been added by all stages of this projectile.
 	double speed = 0.;
 	double clip = 1.;
 	int lifetime = 0;


### PR DESCRIPTION
Get the *actual* speed of the grandparent instead of assuming that all random velocities applied were 50%.